### PR TITLE
Bump API version to v0.6.

### DIFF
--- a/views/layout.jade
+++ b/views/layout.jade
@@ -13,6 +13,6 @@ html
 
     script(src='//code.jquery.com/jquery-2.1.3.min.js')
     script(src='/vendor/bootstrap/dist/js/bootstrap.min.js')
-    script(src='//www.desmos.com/api/v0.4/calculator.js?apiKey=dcb31709b452b1cf9dc26972add0fda6')
+    script(src='//www.desmos.com/api/v0.6/calculator.js?apiKey=dcb31709b452b1cf9dc26972add0fda6')
     script(src='/vendor/gifshot/gifshot.custom.min.js')
     script(src='/js/application.js')


### PR DESCRIPTION
I think it makes sense to run gifsmos on the experimental version of the API,
because it explicitly suggests that you paste links from www, and we don't
guarantee that new states will open in old versions of the API.

Specifically motivated by wanting to have implicit inequalities work with
gifsmos.

https://twitter.com/dandersod/status/636359089220624384