### PR TITLE
Allow user to specify filename for download (#5)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5508,7 +5508,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5526,11 +5527,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5543,15 +5546,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5654,7 +5660,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5664,6 +5671,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5676,17 +5684,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -5703,6 +5714,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5775,7 +5787,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5785,6 +5798,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5860,7 +5874,8 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5890,6 +5905,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5907,6 +5923,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5945,11 +5962,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },
@@ -11867,6 +11886,11 @@
         "loose-envify": "^1.4.0",
         "symbol-observable": "^1.2.0"
       }
+    },
+    "redux-devtools-extension": {
+      "version": "2.13.8",
+      "resolved": "https://registry.npmjs.org/redux-devtools-extension/-/redux-devtools-extension-2.13.8.tgz",
+      "integrity": "sha512-8qlpooP2QqPtZHQZRhx3x3OP5skEV1py/zUdMY28WNAocbafxdG2tRD1MWE7sp8obGMNYuLWanhhQ7EQvT1FBg=="
     },
     "redux-mock-store": {
       "version": "1.5.3",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "react-redux": "^6.0.0",
     "react-scripts": "2.1.2",
     "redux": "^4.0.1",
+    "redux-devtools-extension": "^2.13.8",
     "redux-thunk": "^2.3.0"
   },
   "scripts": {

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -53,6 +53,11 @@ export const updateGIFProgress = progress => ({
   payload: { progress }
 });
 
+export const addText = text => ({
+  type: types.ADD_TEXT,
+  payload: { text }
+});
+
 export const addGIF = imageData => ({
   type: types.ADD_GIF,
   payload: { imageData }

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -62,6 +62,7 @@ export const updateTextColor = fontColor => ({
   type: types.UPDATE_TEXT_COLOR,
   payload: { fontColor }
 });
+
 export const updateGIFFileName = name => {
   return {
     type: types.UPDATE_GIF_FILENAME,

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -56,7 +56,7 @@ export const updateGIFProgress = progress => ({
 export const updateGifFileName = name => {
   return {
     type: types.UPDATE_GIF_FILENAME,
-    payload: { gifFileName: name }
+    payload: { gifFileName: `${name}.gif` }
   };
 };
 

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -53,6 +53,13 @@ export const updateGIFProgress = progress => ({
   payload: { progress }
 });
 
+export const updateGifFileName = name => {
+  return {
+    type: types.UPDATE_GIF_FILENAME,
+    payload: { gifFileName: name }
+  };
+};
+
 export const addGIF = imageData => ({
   type: types.ADD_GIF,
   payload: { imageData }

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -58,6 +58,11 @@ export const addText = text => ({
   payload: { text }
 });
 
+export const addTextColor = fontColor => ({
+  type: types.ADD_TEXT_COLOR,
+  payload: { fontColor }
+});
+
 export const addGIF = imageData => ({
   type: types.ADD_GIF,
   payload: { imageData }

--- a/src/components/GenerateGifForm.css
+++ b/src/components/GenerateGifForm.css
@@ -1,0 +1,43 @@
+.GenerateGifForm-input {
+  display: block;
+  height: 20px;
+  width: 200px;
+  margin: 15px auto 0;
+  border: 1px solid #000;
+  font-size: 1em;
+  border-radius: 5px;
+  padding: 5px;
+  outline: none !important;
+  text-align: center;
+}
+
+.GenerateGifForm-input-error {
+  border-color: #cc0000;
+}
+
+.GenerateGifForm-button {
+  width: 210px;
+  height: 35px;
+  margin-top: 15px;
+  font-size: 1em;
+  background: transparent;
+  border: 1px solid #fff;
+  border-radius: 5px;
+  color: #fff;
+  cursor: pointer;
+  outline: none !important;
+  animation: fade-in 0.5s;
+}
+
+.GenerateGifForm-button:hover {
+  background: #484848;
+}
+
+.GenerateGifForm-button:active {
+  background: #3b3b3b;
+}
+
+.GenerateGifForm-button:focus {
+  border-color: #e79600;
+  background: #484848;
+}

--- a/src/components/GenerateGifForm.js
+++ b/src/components/GenerateGifForm.js
@@ -14,14 +14,20 @@ class GenerateGifForm extends Component {
   }
 
   handleInputUpdate(evt) {
-    if (evt.target.name === 'caption') {
-      this.props.updateText(evt.target.value);
-    }
-    if (evt.target.name === 'fontColor') {
-      this.props.updateTextColor(evt.target.value);
-    }
-    if (evt.target.name === 'name') {
-      this.props.updateGIFFileName(evt.target.value);
+    switch (evt.target.name) {
+      case 'caption':
+        this.props.updateText(evt.target.value);
+        break;
+      case 'fontColor':
+        this.props.updateTextColor(evt.target.value);
+        break;
+
+      case 'name':
+        this.props.updateGIFFileName(evt.target.value);
+        break;
+
+      default:
+        break;
     }
   }
 

--- a/src/components/GenerateGifForm.js
+++ b/src/components/GenerateGifForm.js
@@ -11,8 +11,6 @@ class GenerateGifForm extends Component {
   handleSubmit(evt) {
     evt.preventDefault();
     this.props.handleGenerateGIF();
-    this.props.updateText('');
-    this.props.updateTextColor('');
   }
 
   handleInputUpdate(evt) {

--- a/src/components/GenerateGifForm.js
+++ b/src/components/GenerateGifForm.js
@@ -12,7 +12,9 @@ class GenerateGifForm extends Component {
   handleSubmit(evt) {
     evt.preventDefault();
     this.props.handleGenerateGIF();
-    this.setState({ text: '' });
+    this.props.updateGifFileName(this.state.name);
+    // set title
+    this.setState({ name: '', titleText: '' });
   }
 
   handleInputUpdate(evt) {

--- a/src/components/GenerateGifForm.js
+++ b/src/components/GenerateGifForm.js
@@ -4,15 +4,16 @@ import './GenerateGifForm.css';
 class GenerateGifForm extends Component {
   constructor(props) {
     super(props);
-    this.state = { name: '', titleText: '' };
+    this.state = { name: '', caption: '' };
     this.handleInputUpdate = this.handleInputUpdate.bind(this);
     this.handleSubmit = this.handleSubmit.bind(this);
   }
 
   handleSubmit(evt) {
     evt.preventDefault();
+    this.props.addText(this.state.caption);
     this.props.handleGenerateGIF();
-    this.setState({ text: '' });
+    this.setState({ name: '', caption: '' });
   }
 
   handleInputUpdate(evt) {
@@ -33,10 +34,10 @@ class GenerateGifForm extends Component {
         />
         <input
           className="GenerateGifForm-input"
-          name="titleText"
-          value={this.state.titleText}
+          name="caption"
+          value={this.state.caption}
           onChange={this.handleInputUpdate}
-          placeholder="add title text"
+          placeholder="add caption"
         />
         <button
           className="GenerateGifForm-button"

--- a/src/components/GenerateGifForm.js
+++ b/src/components/GenerateGifForm.js
@@ -1,0 +1,53 @@
+import React, { Component } from 'react';
+import './GenerateGifForm.css';
+
+class GenerateGifForm extends Component {
+  constructor(props) {
+    super(props);
+    this.state = { name: '', titleText: '' };
+    this.handleInputUpdate = this.handleInputUpdate.bind(this);
+    this.handleSubmit = this.handleSubmit.bind(this);
+  }
+
+  handleSubmit(evt) {
+    evt.preventDefault();
+    this.props.handleGenerateGIF();
+    this.setState({ text: '' });
+  }
+
+  handleInputUpdate(evt) {
+    this.setState({
+      [evt.target.name]: evt.target.value
+    });
+  }
+
+  render() {
+    return (
+      <form onSubmit={this.handleSubmit}>
+        <input
+          className="GenerateGifForm-input"
+          name="name"
+          value={this.state.name}
+          onChange={this.handleInputUpdate}
+          placeholder="pick a name for your GIF"
+        />
+        <input
+          className="GenerateGifForm-input"
+          name="titleText"
+          value={this.state.titleText}
+          onChange={this.handleInputUpdate}
+          placeholder="add title text"
+        />
+        <button
+          className="GenerateGifForm-button"
+          aria-label="generate gif"
+          type="submit"
+        >
+          Generate GIF
+        </button>
+      </form>
+    );
+  }
+}
+
+export default GenerateGifForm;

--- a/src/components/GenerateGifForm.js
+++ b/src/components/GenerateGifForm.js
@@ -4,22 +4,24 @@ import './GenerateGifForm.css';
 class GenerateGifForm extends Component {
   constructor(props) {
     super(props);
-    this.state = { name: '', caption: '' };
     this.handleInputUpdate = this.handleInputUpdate.bind(this);
     this.handleSubmit = this.handleSubmit.bind(this);
   }
 
   handleSubmit(evt) {
     evt.preventDefault();
-    this.props.addText(this.state.caption);
     this.props.handleGenerateGIF();
-    this.setState({ name: '', caption: '' });
+    this.props.addText('');
+    this.props.addTextColor('');
   }
 
   handleInputUpdate(evt) {
-    this.setState({
-      [evt.target.name]: evt.target.value
-    });
+    if (evt.target.name === 'caption') {
+      this.props.addText(evt.target.value);
+    }
+    if (evt.target.name === 'fontColor') {
+      this.props.addTextColor(evt.target.value);
+    }
   }
 
   render() {
@@ -28,16 +30,21 @@ class GenerateGifForm extends Component {
         <input
           className="GenerateGifForm-input"
           name="name"
-          value={this.state.name}
           onChange={this.handleInputUpdate}
           placeholder="pick a name for your GIF"
         />
         <input
           className="GenerateGifForm-input"
           name="caption"
-          value={this.state.caption}
           onChange={this.handleInputUpdate}
           placeholder="add caption"
+        />
+        <input
+          className="GenerateGifForm-input"
+          name="fontColor"
+          type="color"
+          defaultValue="#E79600"
+          onChange={this.handleInputUpdate}
         />
         <button
           className="GenerateGifForm-button"

--- a/src/components/GenerateGifForm.js
+++ b/src/components/GenerateGifForm.js
@@ -45,7 +45,7 @@ class GenerateGifForm extends Component {
           aria-label="generate gif"
           type="submit"
         >
-          Generate GIF
+          Generate!
         </button>
       </form>
     );

--- a/src/components/Preview.css
+++ b/src/components/Preview.css
@@ -36,37 +36,10 @@
   margin-top: 20px;
 }
 
-.Preview-create-button {
-  width: 210px;
-  height: 35px;
-  margin-top: 10px;
-  font-size: 1em;
-  background: transparent;
-  border: 1px solid #fff;
-  border-radius: 5px;
-  color: #fff;
-  cursor: pointer;
-  outline: none !important;
-  animation: fade-in 0.5s;
-}
-
-.Preview-create-button:hover {
-  background: #484848;
-}
-
-.Preview-create-button:active {
-  background: #3b3b3b;
-}
-
-.Preview-create-button:focus {
-  border-color: #e79600;
-  background: #484848;
-}
-
 .Preview-progress-outer {
   width: 210px;
-  height: 10px;
-  margin: 10px auto;
+  height: 15px;
+  margin: 15px auto 0;
 }
 
 .Preview-progress-inner {

--- a/src/components/Preview.css
+++ b/src/components/Preview.css
@@ -47,6 +47,13 @@
   border-radius: 3px;
 }
 
+.Preview-progress-success {
+  width: 200px;
+  margin: 15px auto 0;
+  text-align: center;
+  color: #fff;
+}
+
 @keyframes fade-in {
   0% {
     opacity: 0;

--- a/src/components/Preview.js
+++ b/src/components/Preview.js
@@ -7,7 +7,6 @@ import './Preview.css';
 class Preview extends Component {
   constructor(props) {
     super(props);
-    this.state = { gifData: this.props.gifData };
     this.handlePreviewUpdate = this.handlePreviewUpdate.bind(this);
     this.handleGenerateGIF = this.handleGenerateGIF.bind(this);
     this.handleTogglePlaying = this.handleTogglePlaying.bind(this);
@@ -28,14 +27,16 @@ class Preview extends Component {
       height,
       oversample,
       interval,
-      generateGIF
+      generateGIF,
+      caption
     } = this.props;
     const images = frameIDs.map(id => frames[id]);
     const multiplier = oversample ? 2 : 1;
     const opts = {
       gifWidth: width * multiplier,
       gifHeight: height * multiplier,
-      interval: interval / 1000
+      interval: interval / 1000,
+      text: caption
     };
     generateGIF(images, opts);
   }
@@ -85,8 +86,11 @@ class Preview extends Component {
           {numFrames ? `${previewIdx + 1} / ${numFrames}` : '0 / 0'}
         </div>
         <div className="Preview-create">
-          {!!numFrames && this.state.gifData.length === 0 ? (
-            <GenerateGifForm handleGenerateGIF={this.handleGenerateGIF} />
+          {!!numFrames && this.props.gifData.length === 0 ? (
+            <GenerateGifForm
+              handleGenerateGIF={this.handleGenerateGIF}
+              addText={this.props.addText}
+            />
           ) : null}
         </div>
         <div className="Preview-progress-outer">

--- a/src/components/Preview.js
+++ b/src/components/Preview.js
@@ -28,7 +28,8 @@ class Preview extends Component {
       oversample,
       interval,
       generateGIF,
-      caption
+      caption,
+      fontColor
     } = this.props;
     const images = frameIDs.map(id => frames[id]);
     const multiplier = oversample ? 2 : 1;
@@ -36,7 +37,8 @@ class Preview extends Component {
       gifWidth: width * multiplier,
       gifHeight: height * multiplier,
       interval: interval / 1000,
-      text: caption
+      text: caption,
+      fontColor: fontColor
     };
     generateGIF(images, opts);
   }
@@ -89,7 +91,9 @@ class Preview extends Component {
           {!!numFrames && this.props.gifData.length === 0 ? (
             <GenerateGifForm
               handleGenerateGIF={this.handleGenerateGIF}
+              defaultColor={this.props.fontColor}
               addText={this.props.addText}
+              addTextColor={this.props.addTextColor}
             />
           ) : null}
         </div>

--- a/src/components/Preview.js
+++ b/src/components/Preview.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import classNames from 'classnames';
 import Frame from './Frame';
-import GenerateGifForm from './GenerateGifForm';
+import GenerateGifFormContainer from '../containers/GenerateGifFormContainer';
 import './Preview.css';
 
 class Preview extends Component {
@@ -89,15 +89,8 @@ class Preview extends Component {
         </div>
         <div className="Preview-create">
           {!!numFrames && this.props.gifData.length === 0 ? (
-            <GenerateGifForm
+            <GenerateGifFormContainer
               handleGenerateGIF={this.handleGenerateGIF}
-              gifFileName={this.props.gifFileName}
-              caption={this.props.caption}
-              fontColor={this.props.fontColor}
-              defaultColor={this.props.fontColor}
-              updateText={this.props.updateText}
-              updateTextColor={this.props.updateTextColor}
-              updateGIFFileName={this.props.updateGIFFileName}
             />
           ) : null}
         </div>
@@ -121,3 +114,11 @@ class Preview extends Component {
 }
 
 export default Preview;
+
+// gifFileName={this.props.gifFileName}
+// caption={this.props.caption}
+// fontColor={this.props.fontColor}
+// defaultColor={this.props.fontColor}
+// updateText={this.props.updateText}
+// updateTextColor={this.props.updateTextColor}
+// updateGIFFileName={this.props.updateGIFFileName}

--- a/src/components/Preview.js
+++ b/src/components/Preview.js
@@ -100,6 +100,11 @@ class Preview extends Component {
             }}
           />
         </div>
+        {gifProgress === 1 ? (
+          <div className="Preview-progress-success">
+            GIF ready for download!
+          </div>
+        ) : null}
       </div>
     );
   }

--- a/src/components/Preview.js
+++ b/src/components/Preview.js
@@ -85,7 +85,10 @@ class Preview extends Component {
         </div>
         <div className="Preview-create">
           {!!numFrames && this.props.gifData.length === 0 ? (
-            <GenerateGifForm handleGenerateGIF={this.handleGenerateGIF} />
+            <GenerateGifForm
+              handleGenerateGIF={this.handleGenerateGIF}
+              updateGifFileName={this.props.updateGifFileName}
+            />
           ) : null}
         </div>
         <div className="Preview-progress-outer">

--- a/src/components/Preview.js
+++ b/src/components/Preview.js
@@ -1,11 +1,13 @@
 import React, { Component } from 'react';
 import classNames from 'classnames';
 import Frame from './Frame';
+import GenerateGifForm from './GenerateGifForm';
 import './Preview.css';
 
 class Preview extends Component {
   constructor(props) {
     super(props);
+    this.state = { gifData: this.props.gifData };
     this.handlePreviewUpdate = this.handlePreviewUpdate.bind(this);
     this.handleGenerateGIF = this.handleGenerateGIF.bind(this);
     this.handleTogglePlaying = this.handleTogglePlaying.bind(this);
@@ -83,15 +85,9 @@ class Preview extends Component {
           {numFrames ? `${previewIdx + 1} / ${numFrames}` : '0 / 0'}
         </div>
         <div className="Preview-create">
-          {!!numFrames && (
-            <button
-              className="Preview-create-button"
-              onClick={this.handleGenerateGIF}
-              aria-label="generate gif"
-            >
-              Generate GIF
-            </button>
-          )}
+          {!!numFrames && this.state.gifData.length === 0 ? (
+            <GenerateGifForm handleGenerateGIF={this.handleGenerateGIF} />
+          ) : null}
         </div>
         <div className="Preview-progress-outer">
           <div

--- a/src/components/Preview.js
+++ b/src/components/Preview.js
@@ -7,7 +7,6 @@ import './Preview.css';
 class Preview extends Component {
   constructor(props) {
     super(props);
-    this.state = { gifData: this.props.gifData };
     this.handlePreviewUpdate = this.handlePreviewUpdate.bind(this);
     this.handleGenerateGIF = this.handleGenerateGIF.bind(this);
     this.handleTogglePlaying = this.handleTogglePlaying.bind(this);
@@ -85,7 +84,7 @@ class Preview extends Component {
           {numFrames ? `${previewIdx + 1} / ${numFrames}` : '0 / 0'}
         </div>
         <div className="Preview-create">
-          {!!numFrames && this.state.gifData.length === 0 ? (
+          {!!numFrames && this.props.gifData.length === 0 ? (
             <GenerateGifForm handleGenerateGIF={this.handleGenerateGIF} />
           ) : null}
         </div>

--- a/src/components/Preview.js
+++ b/src/components/Preview.js
@@ -114,11 +114,3 @@ class Preview extends Component {
 }
 
 export default Preview;
-
-// gifFileName={this.props.gifFileName}
-// caption={this.props.caption}
-// fontColor={this.props.fontColor}
-// defaultColor={this.props.fontColor}
-// updateText={this.props.updateText}
-// updateTextColor={this.props.updateTextColor}
-// updateGIFFileName={this.props.updateGIFFileName}

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -32,7 +32,7 @@ class Sidebar extends Component {
 
   handleDownload() {
     const { gifData } = this.props;
-    download(gifData, 'gifsmos.gif', 'image/gif');
+    download(gifData, this.props.gifFileName, 'image/gif');
   }
 
   handleRequestFrame() {

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -32,7 +32,7 @@ class Sidebar extends Component {
 
   handleDownload() {
     const { gifData } = this.props;
-    download(gifData, this.props.gifFileName, 'image/gif');
+    download(gifData, this.props.gifFileName || 'gifsmos.gif', 'image/gif');
   }
 
   handleRequestFrame() {

--- a/src/constants/action-types.js
+++ b/src/constants/action-types.js
@@ -11,7 +11,7 @@
 export const ADD_FRAME = 'ADD_FRAME';
 export const UPDATE_GIF_PROGRESS = 'UPDATE_GIF_PROGRESS';
 export const ADD_GIF = 'ADD_GIF';
-
+export const ADD_TEXT = 'ADD_TEXT';
 // UI
 export const UPDATE_PREVIEW_IDX = 'UPDATE_PREVIEW_IDX';
 export const TOGGLE_PANE = 'TOGGLE_PANE';

--- a/src/constants/action-types.js
+++ b/src/constants/action-types.js
@@ -12,6 +12,7 @@ export const ADD_FRAME = 'ADD_FRAME';
 export const UPDATE_GIF_PROGRESS = 'UPDATE_GIF_PROGRESS';
 export const ADD_GIF = 'ADD_GIF';
 export const ADD_TEXT = 'ADD_TEXT';
+export const ADD_TEXT_COLOR = 'ADD_TEXT_COLOR';
 // UI
 export const UPDATE_PREVIEW_IDX = 'UPDATE_PREVIEW_IDX';
 export const TOGGLE_PANE = 'TOGGLE_PANE';

--- a/src/constants/action-types.js
+++ b/src/constants/action-types.js
@@ -11,6 +11,7 @@
 export const ADD_FRAME = 'ADD_FRAME';
 export const UPDATE_GIF_PROGRESS = 'UPDATE_GIF_PROGRESS';
 export const ADD_GIF = 'ADD_GIF';
+export const UPDATE_GIF_FILENAME = 'UPDATE_GIF_FILENAME';
 
 // UI
 export const UPDATE_PREVIEW_IDX = 'UPDATE_PREVIEW_IDX';

--- a/src/containers/GenerateGifFormContainer.js
+++ b/src/containers/GenerateGifFormContainer.js
@@ -1,0 +1,26 @@
+import { connect } from 'react-redux';
+import GenerateGifForm from '../components/GenerateGifForm';
+import { updateGIFFileName, updateText, updateTextColor } from '../actions';
+
+const mapStateToProps = (state, ownProps) => {
+  const { images } = state;
+  const { caption, fontColor, gifFileName } = images;
+
+  return {
+    handleGenerateGIF: ownProps.handleGenerateGIF,
+    caption,
+    fontColor,
+    gifFileName
+  };
+};
+
+const GenerateGifFormContainer = connect(
+  mapStateToProps,
+  {
+    updateText,
+    updateTextColor,
+    updateGIFFileName
+  }
+)(GenerateGifForm);
+
+export default GenerateGifFormContainer;

--- a/src/containers/PreviewContainer.js
+++ b/src/containers/PreviewContainer.js
@@ -1,6 +1,7 @@
 import { connect } from 'react-redux';
 import Preview from '../components/Preview';
 import {
+  updateGifFileName,
   generateGIF,
   updatePreviewIdx,
   startAnimation,
@@ -31,7 +32,13 @@ const mapStateToProps = (state, ownProps) => {
 
 const PreviewContainer = connect(
   mapStateToProps,
-  { updatePreviewIdx, generateGIF, startAnimation, stopAnimation }
+  {
+    updatePreviewIdx,
+    generateGIF,
+    updateGifFileName,
+    startAnimation,
+    stopAnimation
+  }
 )(Preview);
 
 export default PreviewContainer;

--- a/src/containers/PreviewContainer.js
+++ b/src/containers/PreviewContainer.js
@@ -5,14 +5,15 @@ import {
   updatePreviewIdx,
   startAnimation,
   stopAnimation,
-  addText
+  addText,
+  addTextColor
 } from '../actions';
 import panes from '../constants/pane-types';
 
 const mapStateToProps = (state, ownProps) => {
   const { images, ui, settings } = state;
   const { expandedPane, previewIdx, playing } = ui;
-  const { frames, frameIDs, gifProgress, gifData, caption } = images;
+  const { frames, frameIDs, gifProgress, gifData, caption, fontColor } = images;
   const { width, height, oversample, interval } = settings.image;
 
   return {
@@ -27,13 +28,21 @@ const mapStateToProps = (state, ownProps) => {
     height,
     oversample,
     interval,
-    caption
+    caption,
+    fontColor
   };
 };
 
 const PreviewContainer = connect(
   mapStateToProps,
-  { updatePreviewIdx, generateGIF, startAnimation, stopAnimation, addText }
+  {
+    updatePreviewIdx,
+    generateGIF,
+    startAnimation,
+    stopAnimation,
+    addText,
+    addTextColor
+  }
 )(Preview);
 
 export default PreviewContainer;

--- a/src/containers/PreviewContainer.js
+++ b/src/containers/PreviewContainer.js
@@ -11,7 +11,7 @@ import panes from '../constants/pane-types';
 const mapStateToProps = (state, ownProps) => {
   const { images, ui, settings } = state;
   const { expandedPane, previewIdx, playing } = ui;
-  const { frames, frameIDs, gifProgress } = images;
+  const { frames, frameIDs, gifProgress, gifData } = images;
   const { width, height, oversample, interval } = settings.image;
 
   return {
@@ -21,6 +21,7 @@ const mapStateToProps = (state, ownProps) => {
     frames,
     frameIDs,
     gifProgress,
+    gifData,
     width,
     height,
     oversample,

--- a/src/containers/PreviewContainer.js
+++ b/src/containers/PreviewContainer.js
@@ -1,28 +1,17 @@
 import { connect } from 'react-redux';
 import Preview from '../components/Preview';
 import {
-  updateGIFFileName,
   generateGIF,
   updatePreviewIdx,
   startAnimation,
-  stopAnimation,
-  updateText,
-  updateTextColor
+  stopAnimation
 } from '../actions';
 import panes from '../constants/pane-types';
 
 const mapStateToProps = (state, ownProps) => {
   const { images, ui, settings } = state;
   const { expandedPane, previewIdx, playing } = ui;
-  const {
-    frames,
-    frameIDs,
-    gifProgress,
-    gifData,
-    caption,
-    fontColor,
-    gifFileName
-  } = images;
+  const { frames, frameIDs, gifProgress, gifData, caption, fontColor } = images;
   const { width, height, oversample, interval } = settings.image;
 
   return {
@@ -38,8 +27,7 @@ const mapStateToProps = (state, ownProps) => {
     oversample,
     interval,
     caption,
-    fontColor,
-    gifFileName
+    fontColor
   };
 };
 
@@ -49,10 +37,7 @@ const PreviewContainer = connect(
     updatePreviewIdx,
     generateGIF,
     startAnimation,
-    stopAnimation,
-    updateText,
-    updateTextColor,
-    updateGIFFileName
+    stopAnimation
   }
 )(Preview);
 

--- a/src/containers/PreviewContainer.js
+++ b/src/containers/PreviewContainer.js
@@ -4,14 +4,15 @@ import {
   generateGIF,
   updatePreviewIdx,
   startAnimation,
-  stopAnimation
+  stopAnimation,
+  addText
 } from '../actions';
 import panes from '../constants/pane-types';
 
 const mapStateToProps = (state, ownProps) => {
   const { images, ui, settings } = state;
   const { expandedPane, previewIdx, playing } = ui;
-  const { frames, frameIDs, gifProgress, gifData } = images;
+  const { frames, frameIDs, gifProgress, gifData, caption } = images;
   const { width, height, oversample, interval } = settings.image;
 
   return {
@@ -25,13 +26,14 @@ const mapStateToProps = (state, ownProps) => {
     width,
     height,
     oversample,
-    interval
+    interval,
+    caption
   };
 };
 
 const PreviewContainer = connect(
   mapStateToProps,
-  { updatePreviewIdx, generateGIF, startAnimation, stopAnimation }
+  { updatePreviewIdx, generateGIF, startAnimation, stopAnimation, addText }
 )(Preview);
 
 export default PreviewContainer;

--- a/src/containers/SidebarContainer.js
+++ b/src/containers/SidebarContainer.js
@@ -5,13 +5,14 @@ import { requestFrame, togglePane, reset } from '../actions';
 const mapStateToProps = (state, ownProps) => {
   const { images, settings, ui } = state;
   const { expandedPane } = ui;
-  const { gifData, frameIDs } = images;
+  const { gifData, frameIDs, gifFileName } = images;
   const { width, height, oversample } = settings.image;
 
   return {
     numFrames: frameIDs.length,
     expandedPane,
     gifData,
+    gifFileName,
     width,
     height,
     oversample

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { createStore, applyMiddleware } from 'redux';
+import { composeWithDevTools } from 'redux-devtools-extension';
 import { Provider } from 'react-redux';
 import thunkMiddleware from 'redux-thunk';
 import rootReducer from './reducers';
@@ -10,7 +11,10 @@ import { togglePane } from './actions';
 import greet from './lib/dev-greeting';
 import './index.css';
 
-const store = createStore(rootReducer, applyMiddleware(thunkMiddleware));
+const store = createStore(
+  rootReducer,
+  composeWithDevTools(applyMiddleware(thunkMiddleware))
+);
 
 const closePane = () => store.dispatch(togglePane(panes.NONE));
 

--- a/src/reducers/images.js
+++ b/src/reducers/images.js
@@ -15,28 +15,32 @@ import {
   UPDATE_IMAGE_SETTING,
   UPDATE_BOUNDS_SETTING,
   UPDATE_STRATEGY,
-  RESET
+  RESET,
+  ADD_TEXT
 } from '../constants/action-types';
 
 const initialState = {
   frames: {},
   frameIDs: [],
   gifProgress: 0,
-  gifData: ''
+  gifData: '',
+  caption: ''
 };
 
 const images = (state = initialState, { type, payload }) => {
   switch (type) {
     case ADD_FRAME: {
       const { id, imageData } = payload;
-      const { frames, frameIDs } = state;
+      const { frames, frameIDs, caption } = state;
       return {
         ...state,
         ...{
           frames: { ...frames, [id]: imageData },
           frameIDs: [...frameIDs, id],
           gifProgress: 0,
-          gifData: ''
+          gifData: '',
+          caption: caption,
+          fontColor: 'black'
         }
       };
     }
@@ -62,6 +66,12 @@ const images = (state = initialState, { type, payload }) => {
           gifProgress: 0,
           gifData: ''
         }
+      };
+
+    case ADD_TEXT:
+      return {
+        ...state,
+        caption: payload.text
       };
 
     case RESET:

--- a/src/reducers/images.js
+++ b/src/reducers/images.js
@@ -12,6 +12,7 @@ import {
   ADD_FRAME,
   UPDATE_GIF_PROGRESS,
   ADD_GIF,
+  UPDATE_GIF_FILENAME,
   UPDATE_IMAGE_SETTING,
   UPDATE_BOUNDS_SETTING,
   UPDATE_STRATEGY,
@@ -22,7 +23,8 @@ const initialState = {
   frames: {},
   frameIDs: [],
   gifProgress: 0,
-  gifData: ''
+  gifData: '',
+  gifFileName: ''
 };
 
 const images = (state = initialState, { type, payload }) => {
@@ -61,6 +63,14 @@ const images = (state = initialState, { type, payload }) => {
         ...{
           gifProgress: 0,
           gifData: ''
+        }
+      };
+
+    case UPDATE_GIF_FILENAME:
+      return {
+        ...state,
+        ...{
+          gifFileName: payload.gifFileName
         }
       };
 

--- a/src/reducers/images.js
+++ b/src/reducers/images.js
@@ -27,7 +27,7 @@ const initialState = {
   gifProgress: 0,
   gifData: '',
   caption: '',
-  fontColor: '#0000',
+  fontColor: '#000000',
   gifFileName: ''
 };
 
@@ -73,9 +73,7 @@ const images = (state = initialState, { type, payload }) => {
     case UPDATE_TEXT:
       return {
         ...state,
-        ...{
-          caption: payload.text
-        }
+        caption: payload.text
       };
 
     case UPDATE_TEXT_COLOR:
@@ -87,9 +85,7 @@ const images = (state = initialState, { type, payload }) => {
     case UPDATE_GIF_FILENAME:
       return {
         ...state,
-        ...{
-          gifFileName: payload.gifFileName
-        }
+        gifFileName: payload.gifFileName
       };
 
     case RESET:

--- a/src/reducers/images.js
+++ b/src/reducers/images.js
@@ -16,7 +16,8 @@ import {
   UPDATE_BOUNDS_SETTING,
   UPDATE_STRATEGY,
   RESET,
-  ADD_TEXT
+  ADD_TEXT,
+  ADD_TEXT_COLOR
 } from '../constants/action-types';
 
 const initialState = {
@@ -24,23 +25,22 @@ const initialState = {
   frameIDs: [],
   gifProgress: 0,
   gifData: '',
-  caption: ''
+  caption: '',
+  fontColor: '#E79600'
 };
 
 const images = (state = initialState, { type, payload }) => {
   switch (type) {
     case ADD_FRAME: {
       const { id, imageData } = payload;
-      const { frames, frameIDs, caption } = state;
+      const { frames, frameIDs } = state;
       return {
         ...state,
         ...{
           frames: { ...frames, [id]: imageData },
           frameIDs: [...frameIDs, id],
           gifProgress: 0,
-          gifData: '',
-          caption: caption,
-          fontColor: 'black'
+          gifData: ''
         }
       };
     }
@@ -71,7 +71,15 @@ const images = (state = initialState, { type, payload }) => {
     case ADD_TEXT:
       return {
         ...state,
-        caption: payload.text
+        ...{
+          caption: payload.text
+        }
+      };
+
+    case ADD_TEXT_COLOR:
+      return {
+        ...state,
+        fontColor: payload.fontColor
       };
 
     case RESET:

--- a/src/reducers/images.js
+++ b/src/reducers/images.js
@@ -24,7 +24,7 @@ const initialState = {
   frameIDs: [],
   gifProgress: 0,
   gifData: '',
-  gifFileName: ''
+  gifFileName: 'gifsmos.gif'
 };
 
 const images = (state = initialState, { type, payload }) => {

--- a/src/reducers/images.js
+++ b/src/reducers/images.js
@@ -27,7 +27,7 @@ const initialState = {
   gifProgress: 0,
   gifData: '',
   caption: '',
-  fontColor: '#E79600',
+  fontColor: '#0000',
   gifFileName: ''
 };
 


### PR DESCRIPTION
Added functionality for "Allow user to specify filename for download" (Issue #5)

I started by creating a "GenerateGifForm" component. This form contains an input for specifying the file name for download, an input for specifying GIF title text (other members of our group are currently working on this and will use this same component), and the "Generate GIF" button that previously lived in the "Preview" component. This button now acts as a submit button for the form.

Next, I changed the render method on the Preview component so that the form is only shown when both the following conditions are met:
- there are frames present in state (from which to generate a GIF)
- there is no GIF data in state (the form should not show when a GIF has already been generated) 
Additionally, I added functionality so that after a user generates a GIF, a success message is rendered.

The file name lives in the `images` state slice (as `gifsmos.gif` initially). I added an action-type (UPDATE_GIF_FILENAME), action (updateGifFileName), and reducer case.

Chris, don't look at this until Alissa approves!
@ctlusto @alissarenz