### PR TITLE
Throws error on burst image capture when user inputs bad expression index

### DIFF
--- a/src/lib/calc-helpers.js
+++ b/src/lib/calc-helpers.js
@@ -27,10 +27,14 @@ export const getImageData = opts =>
  */
 const getExpByIndex = idx => calculator.getExpressions()[idx - 1];
 
-// Returns an error message on failure.
+/**
+ * Returns an error message on failure.
+ * Skips expressions that are not of type 'expression'
+ */
 export const setSliderByIndex = (idx, val) => {
   const exp = getExpByIndex(idx);
   if (!exp) return noSuchExpression(idx);
+  if (exp.type !== 'expression') return notASlider(idx);
 
   const { id, latex } = exp;
   const match = latex.match(/(.+)=/);


### PR DESCRIPTION
Bug fix for (issue #16)
I added an additional check to ensure that the user selects an index with a valid expression, otherwise will throw the `notASlider()` error.