### PR TITLE
Added Hover Functionality for Tooltip over Icons 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /node_modules
 /.pnp
 .pnp.js
+.env
 
 # testing
 /coverage

--- a/src/components/SidebarButton.css
+++ b/src/components/SidebarButton.css
@@ -3,7 +3,7 @@
   border: 1px solid transparent;
   width: 40px;
   height: 40px;
-  margin-top: 10px;
+  margin-top: 15px;
   margin-left: 15px;
   border-radius: 5px;
   font-size: 1em;
@@ -65,4 +65,30 @@
   100% {
     opacity: 1;
   }
+}
+
+.tooltip {
+  position: relative;
+  display: inline-block;
+}
+
+.tooltip .tooltiptext {
+  visibility: hidden;
+  width: 120px;
+  background-color: grey;
+  color: #fff;
+  text-align: center;
+  padding: 5px 0;
+  border-radius: 6px;
+  position: absolute;
+  z-index: 1;
+  top: -5px;
+  left: 105%;
+  opacity: 0;
+  transition: opacity 0.8s;
+}
+
+.tooltip:hover .tooltiptext {
+  visibility: visible;
+  opacity: 1;
 }

--- a/src/components/SidebarButton.js
+++ b/src/components/SidebarButton.js
@@ -27,17 +27,20 @@ const ariaMap = {
 };
 
 const SidebarButton = ({ children, icon, onClick, expanded }) => (
-  <button
-    className={classNames('SidebarButton', {
-      'SidebarButton-expanded': expanded
-    })}
-    onClick={onClick}
-    aria-label={ariaMap[icon]}
-    aria-expanded={expanded}
-  >
-    <img src={iconMap[icon]} alt={`${icon} icon`} />
-    {children}
-  </button>
+  <div className="tooltip">
+    <span className="tooltiptext">{icon[0].toUpperCase() + icon.slice(1)}</span>
+    <button
+      className={classNames('SidebarButton', {
+        'SidebarButton-expanded': expanded
+      })}
+      onClick={onClick}
+      aria-label={ariaMap[icon]}
+      aria-expanded={expanded}
+    >
+      <img src={iconMap[icon]} alt={`${icon} icon`} />
+      {children}
+    </button>
+  </div>
 );
 
 export default SidebarButton;


### PR DESCRIPTION
I added functionality that allows us to hover over the icons and see what they are called. I also added extra spacing between the icons to allow users to better click on the icons. (#28)

<img width="219" alt="Screen Shot 2019-06-17 at 3 29 36 PM" src="https://user-images.githubusercontent.com/45407194/59641188-708adc00-9115-11e9-9f09-ee960497b266.png">

