### PR TITLE
Error should be raised when we try to set slider of output variable [#19]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1599,7 +1599,7 @@
         },
         "util": {
           "version": "0.10.3",
-          "resolved": "http://registry.npmjs.org/util/-/util-0.10.3.tgz",
+          "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
           "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
           "requires": {
             "inherits": "2.0.1"
@@ -1732,7 +1732,7 @@
         },
         "supports-color": {
           "version": "2.0.0",
-          "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
         }
       }
@@ -2384,7 +2384,7 @@
       "dependencies": {
         "resolve": {
           "version": "1.1.7",
-          "resolved": "http://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
           "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
         }
       }
@@ -3277,7 +3277,7 @@
         },
         "regexpu-core": {
           "version": "1.0.0",
-          "resolved": "http://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
           "integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
           "requires": {
             "regenerate": "^1.2.1",
@@ -3287,12 +3287,12 @@
         },
         "regjsgen": {
           "version": "0.2.0",
-          "resolved": "http://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
           "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc="
         },
         "regjsparser": {
           "version": "0.1.5",
-          "resolved": "http://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+          "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
           "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
           "requires": {
             "jsesc": "~0.5.0"
@@ -3656,7 +3656,7 @@
           "dependencies": {
             "pify": {
               "version": "2.3.0",
-              "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
               "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
             }
           }
@@ -5508,7 +5508,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5526,11 +5527,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5543,15 +5546,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5654,7 +5660,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5664,6 +5671,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5676,17 +5684,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -5703,6 +5714,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5775,7 +5787,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5785,6 +5798,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5860,7 +5874,8 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5890,6 +5905,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5907,6 +5923,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5945,11 +5962,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },
@@ -8513,7 +8532,7 @@
     },
     "media-typer": {
       "version": "0.3.0",
-      "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
     },
     "mem": {
@@ -8653,7 +8672,7 @@
     },
     "minimist": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
     "mississippi": {
@@ -8710,7 +8729,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
@@ -8718,7 +8737,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         }
       }
@@ -8763,13 +8782,13 @@
     },
     "mute-stream": {
       "version": "0.0.7",
-      "resolved": "http://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
     },
     "nan": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.12.1.tgz",
-      "integrity": "sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
       "optional": true
     },
     "nanomatch": {
@@ -9110,7 +9129,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.10",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
           "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
         },
         "wordwrap": {
@@ -9157,7 +9176,7 @@
     },
     "os-homedir": {
       "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
     },
     "os-locale": {
@@ -9172,7 +9191,7 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "p-defer": {
@@ -9293,7 +9312,7 @@
     },
     "path-browserify": {
       "version": "0.0.0",
-      "resolved": "http://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
       "integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo="
     },
     "path-dirname": {
@@ -9308,7 +9327,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-is-inside": {
@@ -10950,7 +10969,7 @@
     },
     "pretty-bytes": {
       "version": "4.0.2",
-      "resolved": "http://registry.npmjs.org/pretty-bytes/-/pretty-bytes-4.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-4.0.2.tgz",
       "integrity": "sha1-sr+C5zUNZcbDOqlaqlpPYyf2HNk="
     },
     "pretty-error": {
@@ -11553,7 +11572,7 @@
     },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "requires": {
         "core-util-is": "~1.0.0",
@@ -12103,7 +12122,7 @@
     },
     "require-uncached": {
       "version": "1.0.3",
-      "resolved": "http://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "requires": {
         "caller-path": "^0.1.0",
@@ -12191,7 +12210,7 @@
     },
     "rgba-regex": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/rgba-regex/-/rgba-regex-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/rgba-regex/-/rgba-regex-1.0.0.tgz",
       "integrity": "sha1-QzdOLiyglosO8VI0YLfXMP8i7rM="
     },
     "rimraf": {
@@ -12253,7 +12272,7 @@
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "requires": {
         "ret": "~0.1.10"
@@ -12773,7 +12792,7 @@
     },
     "sha.js": {
       "version": "2.4.11",
-      "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "requires": {
         "inherits": "^2.0.1",
@@ -13167,7 +13186,7 @@
     },
     "sprintf-js": {
       "version": "1.0.3",
-      "resolved": "http://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "sshpk": {
@@ -13318,7 +13337,7 @@
     },
     "string_decoder": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "requires": {
         "safe-buffer": "~5.1.0"
@@ -13336,7 +13355,7 @@
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
         "ansi-regex": "^2.0.0"
@@ -13361,7 +13380,7 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
     },
     "strip-indent": {
@@ -13468,7 +13487,7 @@
     },
     "table": {
       "version": "4.0.3",
-      "resolved": "http://registry.npmjs.org/table/-/table-4.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/table/-/table-4.0.3.tgz",
       "integrity": "sha512-S7rnFITmBH1EnyKcvxBh1LjYeQMmnZtCXSEbHcH6S0NoKit24ZuFO/T1vDcLdYsLQkM188PVVhQmzKIuThNkKg==",
       "requires": {
         "ajv": "^6.0.1",
@@ -13561,7 +13580,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {
@@ -13654,7 +13673,7 @@
     },
     "topo": {
       "version": "2.0.2",
-      "resolved": "http://registry.npmjs.org/topo/-/topo-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/topo/-/topo-2.0.2.tgz",
       "integrity": "sha1-zVYVdSU5BXwNwEkaYhw7xvvh0YI=",
       "requires": {
         "hoek": "4.x.x"
@@ -13694,7 +13713,7 @@
     },
     "tty-browserify": {
       "version": "0.0.0",
-      "resolved": "http://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
       "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY="
     },
     "tunnel-agent": {
@@ -14111,7 +14130,7 @@
     },
     "vm-browserify": {
       "version": "0.0.4",
-      "resolved": "http://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
       "integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
       "requires": {
         "indexof": "0.0.1"
@@ -14941,7 +14960,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "requires": {
         "string-width": "^1.0.1",
@@ -14958,7 +14977,7 @@
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": "http://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "requires": {
             "code-point-at": "^1.0.0",
@@ -15031,7 +15050,7 @@
     },
     "yargs": {
       "version": "11.1.0",
-      "resolved": "http://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
       "integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
       "requires": {
         "cliui": "^4.0.0",

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -27,12 +27,17 @@
  */
 
 import * as types from '../constants/action-types';
-import { setSliderByIndex, getImageData } from '../lib/calc-helpers';
+import {
+  setSliderByIndex,
+  getImageData,
+  getSliderExpressions
+} from '../lib/calc-helpers';
 import { startTimer, clearTimer } from '../lib/timer';
 import {
   gifCreationProblem,
   badBurstInput,
-  badSettingsInput
+  badSettingsInput,
+  noSlidersFound
 } from '../lib/error-messages';
 import { getBurstErrors, getSettingsErrors } from '../lib/input-helpers';
 
@@ -217,3 +222,16 @@ export const generateGIF = (images, opts) => (dispatch, getState) => {
     }
   });
 };
+
+export const getBurstSliders = () => dispatch => {
+  const sliders = getSliderExpressions();
+  if (!sliders.length) {
+    dispatch(flashError(noSlidersFound()));
+  }
+  dispatch(updateBurstSliders(sliders));
+};
+
+const updateBurstSliders = sliders => ({
+  type: types.UPDATE_BURST_SLIDERS,
+  payload: sliders
+});

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -124,6 +124,11 @@ export const reset = () => {
   return { type: types.RESET };
 };
 
+const updateBurstSliders = sliders => ({
+  type: types.UPDATE_BURST_SLIDERS,
+  payload: sliders
+});
+
 // Thunks
 export const flashError = message => dispatch => {
   clearTimeout(errorTimeout);
@@ -230,8 +235,3 @@ export const getBurstSliders = () => dispatch => {
   }
   dispatch(updateBurstSliders(sliders));
 };
-
-const updateBurstSliders = sliders => ({
-  type: types.UPDATE_BURST_SLIDERS,
-  payload: sliders
-});

--- a/src/components/Burst.css
+++ b/src/components/Burst.css
@@ -41,10 +41,6 @@
   outline: none !important;
 }
 
-.Burst-text-italic {
-  font-style: italic;
-}
-
 .Burst-input-error {
   border-color: #cc0000;
 }

--- a/src/components/Burst.css
+++ b/src/components/Burst.css
@@ -31,6 +31,20 @@
   text-align: center;
 }
 
+.Burst-dropdown {
+  height: 33px;
+  width: 114px;
+  margin-bottom: 15px;
+  margin-top: 5px;
+  border: 1px solid #000;
+  font-size: 1em;
+  outline: none !important;
+}
+
+.Burst-text-italic {
+  font-style: italic;
+}
+
 .Burst-input-error {
   border-color: #cc0000;
 }

--- a/src/components/Burst.js
+++ b/src/components/Burst.js
@@ -46,7 +46,9 @@ class Burst extends Component {
       <div className={classNames('Burst', { 'Burst-expanded': expanded })}>
         <div>Slider</div>
         <select
-          className="Burst-dropdown"
+          className={classNames('Burst-dropdown', {
+            'Burst-input-error': !!errors.idx
+          })}
           name="idx"
           aria-label="slider index"
           onChange={this.handleInputUpdate}

--- a/src/components/Burst.js
+++ b/src/components/Burst.js
@@ -54,12 +54,11 @@ class Burst extends Component {
           onChange={this.handleInputUpdate}
         >
           <option value={null} defaultValue>
-            {burstSliders.length ? 'Choose Slider' : 'No Sliders'}
+            {burstSliders.length ? 'Pick Slider' : 'No Sliders'}
           </option>
           {burstSliders.map(exp => {
             return (
-              <option key={`slider-${exp.id}`} value={exp.id}>
-                {' '}
+              <option key={`slider-${exp.id}`} value={exp.expressionIdx}>
                 {exp.latex.split('=').join(' = ')}
               </option>
             );

--- a/src/components/Burst.js
+++ b/src/components/Burst.js
@@ -6,9 +6,8 @@ import './Burst.css';
 class Burst extends Component {
   constructor(props) {
     super(props);
-
     this.state = {
-      idx: 1,
+      idx: null,
       min: -10,
       max: 10,
       step: 1,
@@ -38,24 +37,32 @@ class Burst extends Component {
   }
 
   render() {
-    const { idx, min, max, step, errors } = this.state;
-    const { expanded } = this.props;
+    const { min, max, step, errors } = this.state;
+    const { expanded, burstSliders } = this.props;
 
     if (!expanded) return <div className="Burst" />;
 
     return (
       <div className={classNames('Burst', { 'Burst-expanded': expanded })}>
-        <div>Slider Index</div>
-        <input
-          className={classNames('Burst-input', {
-            'Burst-input-error': !!errors.idx
-          })}
-          type="number"
+        <div>Slider</div>
+        <select
+          className="Burst-dropdown"
           name="idx"
           aria-label="slider index"
-          value={isNaN(idx) ? '' : idx}
           onChange={this.handleInputUpdate}
-        />
+        >
+          <option value={null} defaultValue>
+            {burstSliders.length ? 'Choose Slider' : 'No Sliders'}
+          </option>
+          {burstSliders.map(exp => {
+            return (
+              <option key={`slider-${exp.id}`} value={exp.id}>
+                {' '}
+                {exp.latex.split('=').join(' = ')}
+              </option>
+            );
+          })}
+        </select>
         <div>Slider Min</div>
         <input
           className={classNames('Burst-input', {

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -21,8 +21,9 @@ class Sidebar extends Component {
   }
 
   handleToggleBurst() {
-    const { togglePane } = this.props;
+    const { togglePane, getBurstSliders, expandedPane } = this.props;
     togglePane(panes.BURST);
+    if (expandedPane !== 'BURST') getBurstSliders();
   }
 
   handleToggleSettings() {

--- a/src/constants/action-types.js
+++ b/src/constants/action-types.js
@@ -19,6 +19,7 @@ export const PLAY_PREVIEW = 'PLAY_PREVIEW';
 export const PAUSE_PREVIEW = 'PAUSE_PREVIEW';
 export const SET_ERROR = 'SET_ERROR';
 export const CLEAR_ERROR = 'CLEAR_ERROR';
+export const UPDATE_BURST_SLIDERS = 'UPDATE_BURST_SLIDERS';
 
 // Settings
 export const UPDATE_IMAGE_SETTING = 'UPDATE_IMAGE_SETTING';

--- a/src/containers/BurstContainer.js
+++ b/src/containers/BurstContainer.js
@@ -11,7 +11,8 @@ const mapStateToProps = (state, ownProps) => {
     expanded: ui.expandedPane === panes.BURST,
     width,
     height,
-    oversample
+    oversample,
+    burstSliders: ui.burstSliders
   };
 };
 

--- a/src/containers/SidebarContainer.js
+++ b/src/containers/SidebarContainer.js
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux';
 import Sidebar from '../components/Sidebar';
-import { requestFrame, togglePane, reset } from '../actions';
+import { requestFrame, togglePane, reset, getBurstSliders } from '../actions';
 
 const mapStateToProps = (state, ownProps) => {
   const { images, settings, ui } = state;
@@ -23,7 +23,8 @@ const SidebarContainer = connect(
   {
     requestFrame,
     togglePane,
-    reset
+    reset,
+    getBurstSliders
   }
 )(Sidebar);
 

--- a/src/lib/calc-helpers.js
+++ b/src/lib/calc-helpers.js
@@ -39,3 +39,12 @@ export const setSliderByIndex = (idx, val) => {
   const identifier = match[1];
   calculator.setExpression({ id, latex: `${identifier}=${val}` });
 };
+
+export const getSliderExpressions = () => {
+  return calculator
+    .getExpressions()
+    .filter(
+      exp =>
+        exp.latex && exp.latex !== '' && exp.latex.match(/[a-z]/gi).length === 1
+    );
+};

--- a/src/lib/calc-helpers.js
+++ b/src/lib/calc-helpers.js
@@ -43,6 +43,7 @@ export const setSliderByIndex = (idx, val) => {
 export const getSliderExpressions = () => {
   return calculator
     .getExpressions()
+    .map((exp, i) => ({ ...exp, expressionIdx: i + 1 }))
     .filter(
       exp =>
         exp.latex && exp.latex !== '' && exp.latex.match(/[a-z]/gi).length === 1

--- a/src/lib/error-messages.js
+++ b/src/lib/error-messages.js
@@ -42,7 +42,7 @@ export const badBurstInput = errors => {
   }
 
   if (propText === propMap.idx)
-    return `Please choose a slider or define an expression`;
+    return `Please choose a slider or define an expression.`;
 
   return `Your ${propText} isn't quite right.`;
 };

--- a/src/lib/error-messages.js
+++ b/src/lib/error-messages.js
@@ -11,6 +11,8 @@ export const noSuchExpression = idx =>
 export const notASlider = idx =>
   `Looks like expression ${idx} doesn't define a slider.`;
 
+export const noSlidersFound = () => `Looks like the graph has no sliders.`;
+
 export const gifCreationProblem = () =>
   'There was a problem creating your GIF. :(';
 
@@ -40,7 +42,7 @@ export const badBurstInput = errors => {
   }
 
   if (propText === propMap.idx)
-    return `Your ${propText} must be a positive integer.`;
+    return `Please choose a slider or define an expression`;
 
   return `Your ${propText} isn't quite right.`;
 };

--- a/src/lib/input-helpers.js
+++ b/src/lib/input-helpers.js
@@ -16,7 +16,7 @@ export const getBurstErrors = inputs => {
     if (isNaN(inputs[prop])) errors[prop] = true;
   }
 
-  if (!isPositiveInteger(idx)) errors.idx = true;
+  if (!idx) errors.idx = true;
   if (min >= max) {
     errors.min = true;
     errors.max = true;

--- a/src/reducers/ui.js
+++ b/src/reducers/ui.js
@@ -6,6 +6,7 @@
  * previewIdx: the index of the frame being previewed in the preview pane
  * playing: whether the preview is animating
  * error: currently displayed error message
+ * burstSliders: expressions from the calculator that are valid sliders
  */
 
 import {
@@ -15,7 +16,8 @@ import {
   PAUSE_PREVIEW,
   SET_ERROR,
   CLEAR_ERROR,
-  RESET
+  RESET,
+  UPDATE_BURST_SLIDERS
 } from '../constants/action-types';
 import panes from '../constants/pane-types';
 
@@ -23,7 +25,8 @@ const initialState = {
   expandedPane: panes.NONE,
   previewIdx: 0,
   playing: false,
-  error: ''
+  error: '',
+  burstSliders: []
 };
 
 const ui = (state = initialState, { type, payload }) => {
@@ -87,6 +90,13 @@ const ui = (state = initialState, { type, payload }) => {
           error: ''
         }
       };
+
+    case UPDATE_BURST_SLIDERS: {
+      return {
+        ...state,
+        burstSliders: payload
+      };
+    }
 
     default:
       return state;


### PR DESCRIPTION
**[issue #19] 
the problem:**

When the user inputs an expression index that doesn't correspond to a slider, the expression can be overridden by the slider, screenshots & gif below for y=mx + b:

<img width="433" alt="Screen Shot 2019-06-18 at 3 30 10 PM" src="https://user-images.githubusercontent.com/32443210/59724297-333e5100-91de-11e9-9152-8626b4b5547f.png">

capture burst, slider index set to 1, produces the following:

![y_mx_b](https://user-images.githubusercontent.com/32443210/59724375-6da7ee00-91de-11e9-9fee-b90d64c38fe1.gif)

My aim was to only allow the user to select from sliders that wont override expressions by filtering the expressions list from calculator.getExpressions() for only expressions whose latex follows the pattern of 1 variable being assigned a numerical value. I implemented a dropdown menu, with default values that throw errors when the users tries to capture an image burst. If there are no sliders, the defaul option is simply No Sliders.

<img width="270" alt="Screen Shot 2019-06-18 at 3 36 18 PM" src="https://user-images.githubusercontent.com/32443210/59724478-dabb8380-91de-11e9-8508-b320f9a605ec.png">

To do this, I needed to add `burstSlider` to the redux store in ui, which gets updated every time the burst panel is opened.

@ctlusto 
@alissarenz 
@mmmaaatttttt
Chris, please wait for Alissa to approve before review!
