### PR TITLE
Allow for undo burst functionality (#36)

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -27,7 +27,12 @@
  */
 
 import * as types from '../constants/action-types';
-import { setSliderByIndex, getImageData } from '../lib/calc-helpers';
+import {
+  setSliderByIndex,
+  getImageData,
+  getCalcState,
+  setCalcState
+} from '../lib/calc-helpers';
 import { startTimer, clearTimer } from '../lib/timer';
 import {
   gifCreationProblem,
@@ -140,12 +145,27 @@ export const requestFrame = opts => async dispatch => {
 };
 
 export const requestBurst = opts => async (dispatch, getState) => {
-  const { idx, min, max, step, width, height, oversample } = opts;
+  const {
+    idx,
+    min,
+    max,
+    step,
+    width,
+    height,
+    oversample,
+    frames,
+    frameIDs
+  } = opts;
   const imageOpts = {
     width,
     height,
     targetPixelRatio: oversample ? 2 : 1
   };
+
+  // grab calculator state prior to capture
+  const prevFrames = { ...frames };
+  const prevFrameIDs = [...frameIDs];
+  const prevCalcState = getCalcState();
 
   // Check for errors in the current pane first.
   const burstErrors = getBurstErrors({ idx, min, max, step });
@@ -173,6 +193,13 @@ export const requestBurst = opts => async (dispatch, getState) => {
     imageData = await getImageData(imageOpts);
     dispatch(addFrame(imageData));
   }
+
+  // return data prior to burst capture for undo
+  return {
+    prevFrames,
+    prevFrameIDs,
+    prevCalcState
+  };
 };
 
 export const startAnimation = () => (dispatch, getState) => {

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -176,7 +176,6 @@ export const requestBurst = opts => async (dispatch, getState) => {
     return;
   }
 
-  //
   const prevFrames = { ...frames };
   const prevFrameIDs = [...frameIDs];
 
@@ -193,7 +192,6 @@ export const requestBurst = opts => async (dispatch, getState) => {
     dispatch(addFrame(imageData));
   }
 
-  //
   return { prevFrames, prevFrameIDs };
 };
 

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -27,12 +27,7 @@
  */
 
 import * as types from '../constants/action-types';
-import {
-  setSliderByIndex,
-  getImageData,
-  getCalcState,
-  setCalcState
-} from '../lib/calc-helpers';
+import { setSliderByIndex, getImageData } from '../lib/calc-helpers';
 import { startTimer, clearTimer } from '../lib/timer';
 import {
   gifCreationProblem,
@@ -61,6 +56,11 @@ export const updateGIFProgress = progress => ({
 export const addGIF = imageData => ({
   type: types.ADD_GIF,
   payload: { imageData }
+});
+
+export const undoBurst = (frames, frameIDs) => ({
+  type: types.UNDO_BURST,
+  payload: { frames, frameIDs }
 });
 
 export const togglePane = pane => {
@@ -162,11 +162,6 @@ export const requestBurst = opts => async (dispatch, getState) => {
     targetPixelRatio: oversample ? 2 : 1
   };
 
-  // grab calculator state prior to capture
-  const prevFrames = { ...frames };
-  const prevFrameIDs = [...frameIDs];
-  const prevCalcState = getCalcState();
-
   // Check for errors in the current pane first.
   const burstErrors = getBurstErrors({ idx, min, max, step });
   if (Object.keys(burstErrors).length) {
@@ -181,6 +176,10 @@ export const requestBurst = opts => async (dispatch, getState) => {
     return;
   }
 
+  //
+  const prevFrames = { ...frames };
+  const prevFrameIDs = [...frameIDs];
+
   let imageData;
   let sliderErrorMessage;
   for (let val = min; val <= max; val += step) {
@@ -194,12 +193,8 @@ export const requestBurst = opts => async (dispatch, getState) => {
     dispatch(addFrame(imageData));
   }
 
-  // return data prior to burst capture for undo
-  return {
-    prevFrames,
-    prevFrameIDs,
-    prevCalcState
-  };
+  //
+  return { prevFrames, prevFrameIDs };
 };
 
 export const startAnimation = () => (dispatch, getState) => {

--- a/src/components/Burst.css
+++ b/src/components/Burst.css
@@ -60,3 +60,8 @@
   background: #484848;
   border-color: #e79600;
 }
+
+.capturing {
+  opacity: 0.5;
+  pointer-events: none;
+}

--- a/src/components/Burst.js
+++ b/src/components/Burst.js
@@ -42,16 +42,13 @@ class Burst extends Component {
   async handleRequestBurst() {
     this.setState({ isCapturing: true });
     const { requestBurst, expanded, frames, frameIDs, ...imgOpts } = this.props;
-    // grab calculator state prior to capture
     const prevCalcState = getCalcState();
-    // capture
     const undoData = await requestBurst({
       ...this.state,
       ...imgOpts,
       frames,
       frameIDs
     });
-    // if capture was successful, update state accordingly
     if (undoData) {
       const { prevFrames, prevFrameIDs } = undoData;
       this.setState({
@@ -61,9 +58,7 @@ class Burst extends Component {
         prevFrameIDs,
         prevCalcState
       });
-    }
-    // update isCapturing regardless
-    else {
+    } else {
       this.setState({ isCapturing: false });
     }
   }
@@ -71,11 +66,8 @@ class Burst extends Component {
   handleUndoBurst() {
     const { undoBurst } = this.props;
     const { prevFrames, prevFrameIDs, prevCalcState } = this.state;
-    // dispatch action to change frames, frameIDs in state
     undoBurst(prevFrames, prevFrameIDs);
-    // revert calculator state
     setCalcState(prevCalcState);
-    // clear out undo data in local state
     this.setState({
       canUndo: false,
       prevFrames: {},

--- a/src/components/Burst.js
+++ b/src/components/Burst.js
@@ -14,6 +14,7 @@ class Burst extends Component {
       max: 10,
       step: 1,
       isCapturing: false,
+      canUndo: false,
       prevFrames: {},
       prevFrameIDs: [],
       prevCalcState: {},
@@ -55,6 +56,7 @@ class Burst extends Component {
       const { prevFrames, prevFrameIDs } = undoData;
       this.setState({
         isCapturing: false,
+        canUndo: true,
         prevFrames,
         prevFrameIDs,
         prevCalcState
@@ -75,6 +77,7 @@ class Burst extends Component {
     setCalcState(prevCalcState);
     // clear out undo data in local state
     this.setState({
+      canUndo: false,
       prevFrames: {},
       prevFrameIDs: [],
       prevCalcState: {}
@@ -144,7 +147,7 @@ class Burst extends Component {
             {this.state.isCapturing ? 'Capturing...' : 'Capture'}
           </button>
         </div>
-        {this.state.prevFrameIDs.length ? (
+        {this.state.canUndo ? (
           <div>
             <button
               className="Burst-button"

--- a/src/components/Burst.js
+++ b/src/components/Burst.js
@@ -7,7 +7,6 @@ import './Burst.css';
 class Burst extends Component {
   constructor(props) {
     super(props);
-
     this.state = {
       idx: 1,
       min: -10,
@@ -24,6 +23,12 @@ class Burst extends Component {
     this.handleInputUpdate = this.handleInputUpdate.bind(this);
     this.handleRequestBurst = this.handleRequestBurst.bind(this);
     this.handleUndoBurst = this.handleUndoBurst.bind(this);
+  }
+
+  componentDidUpdate(prevProps) {
+    if (this.props.frameIDs.length !== prevProps.frameIDs.length) {
+      this.setState({ canUndo: false });
+    }
   }
 
   handleInputUpdate(evt) {

--- a/src/components/Burst.js
+++ b/src/components/Burst.js
@@ -40,7 +40,7 @@ class Burst extends Component {
   }
 
   async handleRequestBurst() {
-    this.setState({ isCapturing: true });
+    this.setState({ isCapturing: true, canUndo: false });
     const { requestBurst, expanded, frames, frameIDs, ...imgOpts } = this.props;
     const prevCalcState = getCalcState();
     const undoData = await requestBurst({

--- a/src/components/Burst.js
+++ b/src/components/Burst.js
@@ -32,9 +32,18 @@ class Burst extends Component {
     this.setState(newState);
   }
 
-  handleRequestBurst() {
-    const { requestBurst, expanded, ...imgOpts } = this.props;
-    requestBurst({ ...this.state, ...imgOpts });
+  async handleRequestBurst() {
+    const { requestBurst, expanded, frames, frameIDs, ...imgOpts } = this.props;
+    // pass frames and frameIDs
+    const dataForUndo = await requestBurst({
+      ...this.state,
+      frames,
+      frameIDs,
+      ...imgOpts
+    });
+    // save undo data to state
+    // if undo data in state, show undo button
+    console.log(dataForUndo);
   }
 
   render() {

--- a/src/constants/action-types.js
+++ b/src/constants/action-types.js
@@ -11,6 +11,7 @@
 export const ADD_FRAME = 'ADD_FRAME';
 export const UPDATE_GIF_PROGRESS = 'UPDATE_GIF_PROGRESS';
 export const ADD_GIF = 'ADD_GIF';
+export const UNDO_BURST = 'UNDO_BURST';
 
 // UI
 export const UPDATE_PREVIEW_IDX = 'UPDATE_PREVIEW_IDX';

--- a/src/containers/BurstContainer.js
+++ b/src/containers/BurstContainer.js
@@ -4,14 +4,17 @@ import { requestBurst } from '../actions';
 import panes from '../constants/pane-types';
 
 const mapStateToProps = (state, ownProps) => {
-  const { settings, ui } = state;
+  const { settings, ui, images } = state;
   const { width, height, oversample } = settings.image;
+  const { frames, frameIDs } = images;
 
   return {
     expanded: ui.expandedPane === panes.BURST,
     width,
     height,
-    oversample
+    oversample,
+    frames,
+    frameIDs
   };
 };
 

--- a/src/containers/BurstContainer.js
+++ b/src/containers/BurstContainer.js
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux';
 import Burst from '../components/Burst';
-import { requestBurst } from '../actions';
+import { requestBurst, undoBurst } from '../actions';
 import panes from '../constants/pane-types';
 
 const mapStateToProps = (state, ownProps) => {
@@ -20,7 +20,7 @@ const mapStateToProps = (state, ownProps) => {
 
 const BurstContainer = connect(
   mapStateToProps,
-  { requestBurst }
+  { requestBurst, undoBurst }
 )(Burst);
 
 export default BurstContainer;

--- a/src/lib/calc-helpers.js
+++ b/src/lib/calc-helpers.js
@@ -39,3 +39,13 @@ export const setSliderByIndex = (idx, val) => {
   const identifier = match[1];
   calculator.setExpression({ id, latex: `${identifier}=${val}` });
 };
+
+// gets current state of calculator instance
+export const getCalcState = () => {
+  return calculator.getState();
+};
+
+// accepts some calculator state and updates calculator instance
+export const setCalcState = state => {
+  return calculator.setState(state);
+};

--- a/src/lib/calc-helpers.js
+++ b/src/lib/calc-helpers.js
@@ -40,12 +40,10 @@ export const setSliderByIndex = (idx, val) => {
   calculator.setExpression({ id, latex: `${identifier}=${val}` });
 };
 
-// gets current state of calculator instance
 export const getCalcState = () => {
   return calculator.getState();
 };
 
-// accepts some calculator state and updates calculator instance
 export const setCalcState = state => {
   return calculator.setState(state);
 };

--- a/src/reducers/images.js
+++ b/src/reducers/images.js
@@ -12,6 +12,7 @@ import {
   ADD_FRAME,
   UPDATE_GIF_PROGRESS,
   ADD_GIF,
+  UNDO_BURST,
   UPDATE_IMAGE_SETTING,
   UPDATE_BOUNDS_SETTING,
   UPDATE_STRATEGY,
@@ -51,6 +52,13 @@ const images = (state = initialState, { type, payload }) => {
       return {
         ...state,
         gifData: payload.imageData
+      };
+
+    case UNDO_BURST:
+      return {
+        ...state,
+        frames: payload.frames,
+        frameIDs: payload.frameIDs
       };
 
     case UPDATE_IMAGE_SETTING:


### PR DESCRIPTION
Implemented 'undo burst' functionality (issue #36).

Summary:
- added functions to get and set calculator state to the calc-helpers file
- mapped frame and frameIDs (from the images state slice) to the Burst component's props
- changed the Burst component's local state to include prevFrames, prevFrameIDs, and prevCalcState to allow for undo
- in handleRequestBurst, im grabbing these three values prior to burst capture
- if the capture is successful, the data is saved in local state
- if unsuccessful, data is not saved
- also added isCapturing to local state to trigger UI change when burst is being captured... capture button changes to 'capturing...' and is unclickable
- when a burst has been captured, an undo button appears in the UI
- added undoBurst action creator, UNDO_BURST action type
- added handleUndoBurst method, dispatches action and reverts calculator